### PR TITLE
Gets the games from dev_hdd0 instead of games.yml

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,10 +2,17 @@
 
 package main
 
+import (
+    "fmt"
+    "os"
+    "runtime"
+)
+
 // Config is the app wide configuration structure
 type Config struct {
 	Rpcs3Path string
 	PkgDLPath string
+	ConfigYMLPath string
 }
 
 var conf Config
@@ -27,7 +34,26 @@ func initConfig() {
 	conf = Config{
 		Rpcs3Path: ".",
 		PkgDLPath: ".",
+        ConfigYMLPath: "",
 	}
+	confFile := "/rpcs3/config.yml"
+    goos := runtime.GOOS
+    switch goos {
+    case "freebsd":
+        fallthrough
+    case "linux":
+        if home := os.Getenv("XDG_CONFIG_HOME"); home != "" {
+            conf.ConfigYMLPath = home + confFile
+        } else if home := os.Getenv("HOME"); home != "" {
+            conf.ConfigYMLPath = home + "/.config" + confFile
+        } else {
+            conf.ConfigYMLPath = "~/.config" + confFile
+        }
+        fmt.Println(conf.ConfigYMLPath)
+    case "windows":
+        conf.ConfigYMLPath = os.Getenv("RPCS3_CONFIG_DIR") + confFile
+    }
+
 	confPath = "."
 }
 


### PR DESCRIPTION
This is what we talked about on reddit.

It's an initial implementation to give you an idea of what I was thinking and for you to tell me how bad my go is. :)

I didn't test the logic on Windows, nor BSD. For the latter I assumed it'd work the same as on Linux but maybe not.

In a few lines, this is how it works:

- It parses the config.yml file at a pre-guessed location depending on the OS (it probably would be nice to allow an override on this), and gets the dev_hdd0 path from it.

- It then loops on dev_hdd0/{disc,game} to get all games installed. It may include game data not quite sure yet.

- Then back to your previous logic

Thanks!