### PR TITLE
RPCS3 does not support macOS but BSD, we should do the same.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Still very much work in progress.
 
 ### Windows
 
-* Install [MSYS2](https://www.msys2.org/) 
-* * Restart your terminal and editors 
+* Install [MSYS2](https://www.msys2.org/)
+* * Restart your terminal and editors
 * `go build`
 
 ### Linux
@@ -26,6 +26,6 @@ Still very much work in progress.
 * Install gcc/g++ and libraries for building (e.g. the *build-essentials* package on Debian/Ubuntu)
 * `go build`
 
-### macOS
+### BSD
 
 * TODOs


### PR DESCRIPTION
I don't know anything about BSD so not sure what to put there.
(I could put instructions for Linux, but that seemed premature at this state)