### PR TITLE
Enabling Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go: 1.14
+before_script:
+  - go get fyne.io/fyne
+  - go get gopkg.in/gookit/color.v1
+script: go build
+os:
+  - linux
+  - windows


### PR DESCRIPTION
A little early, but why not.
Plus that allows us to test multiple OS without vms. :)
Alas as far as I can tell, they don't support BSD.

If you like this, you'll need to setup the TravisCI account yourself since you're the admin of the repos, I don't have the rights to do so.