### PR TITLE
Initial support for checking versions

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -10,6 +10,12 @@ const userAgent string = "Mozilla/5.0 (PLAYSTATION 3; 3.55)"
 
 /* structures */
 
+type GameInfo struct {
+	ID      string
+	URL     string
+	Version string
+}
+
 /* this is the sony titlepatch format */
 
 // Paramsfo contains the title of the game


### PR DESCRIPTION
This unfortunately needs https://github.com/mattn/go-zglob as the standard glob does not support /**/ which is annoying.

It's not perfect as it grabs the version of stuff that it probably should skip.

It also only grabs the version but does not do anything further with it.