### PR TITLE
Send errors to stderr instead of stdout

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"gopkg.in/gookit/color.v1"
 )
@@ -11,7 +12,7 @@ import (
 /* standard print */
 
 func print(format string, a ...interface{}) {
-	fmt.Printf(format+"\n", a...)
+	fmt.Fprintf(os.Stdout, format+"\n", a...)
 }
 
 /* prints debug messages */
@@ -21,10 +22,10 @@ func printDebug(format string, a ...interface{}) {
 		return
 	}
 	if fetchConfig().color {
-		color.Gray.Printf(format+"\n", a...)
-	} else {
-		fmt.Printf(format+"\n", a...)
+		format = color.FgGray.Render(format)
 	}
+	fmt.Fprintf(os.Stdout, format+"\n", a...)
+
 }
 
 /* prints error messages */
@@ -34,10 +35,9 @@ func printError(format string, a ...interface{}) {
 		return
 	}
 	if fetchConfig().color {
-		color.Red.Printf(format+"\n", a...)
-	} else {
-		fmt.Printf(format+"\n", a...)
+		format = color.FgRed.Render(format)
 	}
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
 }
 
 /* prints info messages */
@@ -47,10 +47,9 @@ func printInfo(format string, a ...interface{}) {
 		return
 	}
 	if fetchConfig().color {
-		color.Green.Printf(format+"\n", a...)
-	} else {
-		fmt.Printf(format+"\n", a...)
+		format = color.FgGreen.Render(format)
 	}
+	fmt.Fprintf(os.Stdout, format+"\n", a...)
 }
 
 /* prints warning messages */
@@ -60,20 +59,19 @@ func printWarning(format string, a ...interface{}) {
 		return
 	}
 	if fetchConfig().color {
-		color.Yellow.Printf(format+"\n", a...)
-	} else {
-		fmt.Printf(format+"\n", a...)
+		format = color.FgYellow.Render(format)
 	}
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
 }
 
 /* prints over the same line */
 
 func sameLinePrint(format string, a ...interface{}) {
-	fmt.Print("\033[G\033[K") // move the cursor left and clear the line
-	fmt.Printf(format+"\n", a...)
-	fmt.Print("\033[A") // move the cursor up
+	fmt.Fprint(os.Stdout, "\033[G\033[K") // move the cursor left and clear the line
+	fmt.Fprintf(os.Stdout, format+"\n", a...)
+	fmt.Fprint(os.Stdout, "\033[A") // move the cursor up
 }
 
 func stopSameLinePrint() {
-	fmt.Print("\033[B") // move the cursor down
+	fmt.Fprint(os.Stdout, "\033[B") // move the cursor down
 }


### PR DESCRIPTION
I'm still not sure about having "\n" everywhere instead of once, but I think that's already a bit better.