### PR TITLE
Move downloading the xml in the download.go file and clean it up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ rpcs3-gameupdater
 
 # Test binary, built with `go test -c`
 *.test
-
+XMLs
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Rpcs3Path     string    `toml:"rpcs3path"`
 	PkgDLPath     string    `toml:"pkgdlpath"`
 	ConfigYMLPath string    `toml:"configymlpath"`
+	XMLCachePath  string    `toml:"xmlcache"`
 	DLTimeout     int       `toml:"timeout"`
 	DLRetries     int       `toml:"retries"`
 	verbosity     Verbosity `toml:"verbosity"`
@@ -55,6 +56,7 @@ func initConfig() {
 	conf = Config{
 		Rpcs3Path:     ".",
 		PkgDLPath:     ".",
+		XMLCachePath:  "./XMLs",
 		ConfigYMLPath: "",
 		DLTimeout:     30,
 		DLRetries:     3,
@@ -81,6 +83,10 @@ func initConfig() {
 	}
 	printInfo("config.yml should be at: " + conf.ConfigYMLPath)
 	confPath = "."
+	err := os.MkdirAll(conf.XMLCachePath, 0755)
+	if err != nil {
+		printError("Error creating the XMLCache folder at %s (errorcode: %s)", conf.XMLCachePath, err)
+	}
 }
 
 func parseConfFile() {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/zom-ponks/rpcs3-gameupdater
 go 1.14
 
 require (
-	github.com/cavaliercoder/grab v2.0.1-0.20200331080741-9f014744ee41+incompatible
+	github.com/cavaliercoder/grab v2.0.0+incompatible
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pelletier/go-toml v1.7.0
 	github.com/stretchr/testify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/cavaliercoder/grab v1.0.0 h1:H6VQ1NiLO7AvXM6ZyaInnoZrRLeo2FoUTQEcXln4bvQ=
 github.com/cavaliercoder/grab v2.0.0+incompatible h1:wZHbBQx56+Yxjx2TCGDcenhh3cJn7cCLMfkEPmySTSE=
 github.com/cavaliercoder/grab v2.0.0+incompatible/go.mod h1:tTBkfNqSBfuMmMBFaO2phgyhdYhiZQ/+iXCZDzcDsMI=
-github.com/cavaliercoder/grab v2.0.1-0.20200331080741-9f014744ee41+incompatible h1:WIyGcm5fMRXlTG8k2iwBiAVunhUmCvakMZIYz6yGjKM=
-github.com/cavaliercoder/grab v2.0.1-0.20200331080741-9f014744ee41+incompatible/go.mod h1:tTBkfNqSBfuMmMBFaO2phgyhdYhiZQ/+iXCZDzcDsMI=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rpcs3dl.go
+++ b/rpcs3dl.go
@@ -9,27 +9,24 @@ import (
 	// TODO: figure out if we really need this
 
 	"bufio"
-	"crypto/tls"
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 )
 
 /* parses the given config.yml file and returns the path to dev_hdd0 */
 
-func getGamesPath(configYML string) string {
+func getLocalGamesPath(configYML string) string {
 	printInfo("Parsing '" + configYML)
 	path := ""
 	file, err := os.Open(configYML)
 
 	if err != nil {
-		printError(fmt.Sprintf("Couldn't open '%s' (errorcode: %s)\n", configYML, err))
+		printError("Couldn't open '%s' (errorcode: %s)", configYML, err)
 		return path
 	}
 
@@ -75,7 +72,7 @@ func getCategoryAndVersion(path string) (string, float64) {
 	// finds the PARAM.SFO
 	params, err := filepath.Glob(path + folder + "/PARAM.SFO")
 	if err != nil {
-		printError("Error finding %s/**/PARAM.sfo  (errorcode: %s)\n", path, err)
+		printError("Error finding %s/**/PARAM.sfo  (errorcode: %s)", path, err)
 		return "", 0.0
 	}
 	param := params[0]
@@ -83,7 +80,7 @@ func getCategoryAndVersion(path string) (string, float64) {
 	defer file.Close()
 
 	if err != nil {
-		printError(fmt.Sprintf("Couldn't open '%s' (errorcode: %s)\n", param, err))
+		printError("Couldn't open '%s' (errorcode: %s)", param, err)
 		return "", 0.0
 	}
 	kvp := readParamSFO(file)
@@ -95,17 +92,17 @@ func getCategoryAndVersion(path string) (string, float64) {
 	}
 	versionF, err := strconv.ParseFloat(ver[0:5], 64)
 	if err != nil {
-		printError("Couldn't convert '%s' (errorcode: '%s')\n", ver, err)
+		printError("Couldn't convert '%s' (errorcode: '%s')", ver, err)
 	}
 	return cat, versionF
 }
 
 /* gets games URLs and versions from a specific folder */
 
-func getGamesFromFolder(games map[string]*GameInfo, path string) {
+func getLocalGamesFromFolder(games map[string]*GameInfo, path string) {
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		printError("Couldn't open '%s' (errorcode: '%s')\n", path, err)
+		printError("Couldn't open '%s' (errorcode: '%s')", path, err)
 		return
 	}
 
@@ -133,51 +130,24 @@ func getGamesFromFolder(games map[string]*GameInfo, path string) {
 
 /* gets games URLs and versions from the various folders */
 
-func getGames(path string) map[string]*GameInfo {
+func getLocalGames(path string) map[string]*GameInfo {
 	// first from the disc folder
 	games := make(map[string]*GameInfo)
-	getGamesFromFolder(games, path+"disc/")
+	getLocalGamesFromFolder(games, path+"disc/")
 
 	// then the game folder
-	getGamesFromFolder(games, path+"game/")
+	getLocalGamesFromFolder(games, path+"game/")
 
 	return games
 }
 
-func getGamesFromServer() {
-	printInfo("downloading using config.yml")
-
-	path := getGamesPath(fetchConfig().ConfigYMLPath)
-	games := getGames(path)
-
+func getGamesFromServer(games map[string]*GameInfo) {
 	for gameID, game := range games {
-		printDebug("gameID: %s, url: %s, version: %s", gameID, game.URL, game.Version)
-		url := game.URL
+		printDebug("gameID: %s, url: %s, version: %f", gameID, game.URL, game.Version)
 		//printInfo("fetching URL: '%s'", url)
 
-		// we need this because we can't verify the signature
-		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-
-		httpClient := &http.Client{Transport: transport,
-			Timeout: time.Duration(conf.DLTimeout) * time.Second}
-
-		// TODO: retry logic goes here
-		response, err := httpClient.Get(url)
-
-		if err != nil {
-			printError("Error: Can't open url '%s'", url)
-		}
-		defer response.Body.Close()
-		body, err := ioutil.ReadAll(response.Body)
-
-		if err != nil {
-			printError("can't read response body.")
-			break
-		}
 		patch := TitlePatch{}
-		err = xml.Unmarshal([]byte(body), &patch)
+		err := xml.Unmarshal(getXML(game.URL), &patch)
 
 		if err != nil {
 			printError("can't parse response XML.")
@@ -193,7 +163,7 @@ func getGamesFromServer() {
 				patch.Tag.Package[i].SHA1)
 			version, err := strconv.ParseFloat(patch.Tag.Package[i].Version, 64)
 			if err != nil {
-				printError("Couldn't convert '%s' (errorcode: '%s')\n", patch.Tag.Package[i].Version, err)
+				printError("Couldn't convert '%s' (errorcode: '%s')", patch.Tag.Package[i].Version, err)
 			}
 			if version < game.Version {
 				printDebug("Version %f is inferior to current of %f", version, game.Version)
@@ -209,7 +179,9 @@ func main() {
 	parseArguments()
 	initConfig()
 	initDownloader()
-	getGamesFromServer()
+	path := getLocalGamesPath(fetchConfig().ConfigYMLPath)
+	games := getLocalGames(path)
+	getGamesFromServer(games)
 
 	// test
 	fmt.Printf("Terminal: %v\n", isTTY())

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,7 @@ func IsTTY() bool {
 }
 
 /* verify that the 3 checksums (passed, stored and calculated) match */
-func verifyChecksums(filePath string, sha string) bool {
+func verifyPKGChecksums(filePath string, sha string) bool {
 	file, err := os.Open(filePath)
 	if err != nil {
 		printError("Couldn't open '%s' (errorcode: '%s')\n", filePath, err)


### PR DESCRIPTION
The way this is done, we save the XMLs to disk, which means if they're already there we don't need to download them anymore.

(We could skip checking for resume and just assume the files are good, not sure how much bandwidth we're saving since we let grab check...)

That way we allow caching of the XMLs but don't provide them as per this project. (If the PS3 games weren't that old, the XMLs would need refreshing but at this point I doubt a lot of new patches come out)